### PR TITLE
Added another path option to reach autoload.php

### DIFF
--- a/bin/laminas-development-mode
+++ b/bin/laminas-development-mode
@@ -14,6 +14,8 @@ if (file_exists($a = __DIR__ . '/../../../autoload.php')) {
     require $a;
 } elseif (file_exists($a = __DIR__ . '/../vendor/autoload.php')) {
     require $a;
+} elseif (file_exists($a = __DIR__ . '/../autoload.php')) {
+    require $a;
 } else {
     fwrite(STDERR, 'Cannot locate autoloader; please run "composer install"' . PHP_EOL);
     exit(1);


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Bugfix        | yes/no
| New Feature   | yes/no

### Description

Re-create https://github.com/zfcampus/zf-development-mode/pull/37 by @gailimov Fixes #1 . Original PR description:

```text
There is no symlink in macOS, just a copy of executable which cannot locate autoloader.
But if we, for example, create project inside Docker container using Alpine 3.10 as base
image, it creates symlink to vendor/zfcampus/zf-development-mode/bin/zf-development-mode
and everything works fine as expected.
```
