### PR TITLE
Upgrade laminas-coding-standard to 2.3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "laminas/laminas-zendframework-bridge": "^1.0"
     },
     "require-dev": {
-        "laminas/laminas-coding-standard": "~1.0.0",
+        "laminas/laminas-coding-standard": "~2.3.0",
         "mikey179/vfsstream": "^1.6.10",
         "phpunit/phpunit": "^9.3"
     },

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2e019276ab2121e394361c137f69f55c",
+    "content-hash": "be43f62d7f6b2a72423ae84a1de20f16",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -183,16 +183,16 @@
         },
         {
             "name": "mikey179/vfsstream",
-            "version": "v1.6.8",
+            "version": "v1.6.10",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bovigo/vfsStream.git",
-                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe"
+                "reference": "250c0825537d501e327df879fb3d4cd751933b85"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/231c73783ebb7dd9ec77916c10037eff5a2b6efe",
-                "reference": "231c73783ebb7dd9ec77916c10037eff5a2b6efe",
+                "url": "https://api.github.com/repos/bovigo/vfsStream/zipball/250c0825537d501e327df879fb3d4cd751933b85",
+                "reference": "250c0825537d501e327df879fb3d4cd751933b85",
                 "shasum": ""
             },
             "require": {
@@ -230,7 +230,7 @@
                 "source": "https://github.com/bovigo/vfsStream/tree/master",
                 "wiki": "https://github.com/bovigo/vfsStream/wiki"
             },
-            "time": "2019-10-30T15:31:00+00:00"
+            "time": "2021-09-25T08:05:01+00:00"
         },
         {
             "name": "myclabs/deep-copy",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "be43f62d7f6b2a72423ae84a1de20f16",
+    "content-hash": "13901402840595f973cea15f3915223e",
     "packages": [
         {
             "name": "laminas/laminas-zendframework-bridge",
@@ -70,6 +70,76 @@
         }
     ],
     "packages-dev": [
+        {
+            "name": "dealerdirect/phpcodesniffer-composer-installer",
+            "version": "v0.7.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Dealerdirect/phpcodesniffer-composer-installer.git",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Dealerdirect/phpcodesniffer-composer-installer/zipball/fe390591e0241955f22eb9ba327d137e501c771c",
+                "reference": "fe390591e0241955f22eb9ba327d137e501c771c",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.0 || ^2.0",
+                "php": ">=5.3",
+                "squizlabs/php_codesniffer": "^2.0 || ^3.0 || ^4.0"
+            },
+            "require-dev": {
+                "composer/composer": "*",
+                "phpcompatibility/php-compatibility": "^9.0",
+                "sensiolabs/security-checker": "^4.1.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Dealerdirect\\Composer\\Plugin\\Installers\\PHPCodeSniffer\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Franck Nijhof",
+                    "email": "franck.nijhof@dealerdirect.com",
+                    "homepage": "http://www.frenck.nl",
+                    "role": "Developer / IT Manager"
+                }
+            ],
+            "description": "PHP_CodeSniffer Standards Composer Installer Plugin",
+            "homepage": "http://www.dealerdirect.com",
+            "keywords": [
+                "PHPCodeSniffer",
+                "PHP_CodeSniffer",
+                "code quality",
+                "codesniffer",
+                "composer",
+                "installer",
+                "phpcs",
+                "plugin",
+                "qa",
+                "quality",
+                "standard",
+                "standards",
+                "style guide",
+                "stylecheck",
+                "tests"
+            ],
+            "support": {
+                "issues": "https://github.com/dealerdirect/phpcodesniffer-composer-installer/issues",
+                "source": "https://github.com/dealerdirect/phpcodesniffer-composer-installer"
+            },
+            "time": "2020-12-07T18:04:37+00:00"
+        },
         {
             "name": "doctrine/instantiator",
             "version": "1.4.0",
@@ -141,31 +211,36 @@
         },
         {
             "name": "laminas/laminas-coding-standard",
-            "version": "1.0.0",
+            "version": "2.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laminas/laminas-coding-standard.git",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539"
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/08880ce2fbfe62d471cd3cb766a91da630b32539",
-                "reference": "08880ce2fbfe62d471cd3cb766a91da630b32539",
+                "url": "https://api.github.com/repos/laminas/laminas-coding-standard/zipball/bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
+                "reference": "bcf6e07fe4690240be7beb6d884d0b0fafa6a251",
                 "shasum": ""
             },
             "require": {
-                "laminas/laminas-zendframework-bridge": "^1.0",
-                "squizlabs/php_codesniffer": "^2.7"
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.7",
+                "php": "^7.3 || ^8.0",
+                "slevomat/coding-standard": "^7.0",
+                "squizlabs/php_codesniffer": "^3.6",
+                "webimpress/coding-standard": "^1.2"
             },
-            "replace": {
-                "zendframework/zend-coding-standard": "self.version"
+            "type": "phpcodesniffer-standard",
+            "autoload": {
+                "psr-4": {
+                    "LaminasCodingStandard\\": "src/LaminasCodingStandard/"
+                }
             },
-            "type": "library",
             "notification-url": "https://packagist.org/downloads/",
             "license": [
                 "BSD-3-Clause"
             ],
-            "description": "Laminas coding standard",
+            "description": "Laminas Coding Standard",
             "homepage": "https://laminas.dev",
             "keywords": [
                 "Coding Standard",
@@ -179,7 +254,13 @@
                 "rss": "https://github.com/laminas/laminas-coding-standard/releases.atom",
                 "source": "https://github.com/laminas/laminas-coding-standard"
             },
-            "time": "2019-12-31T16:28:26+00:00"
+            "funding": [
+                {
+                    "url": "https://funding.communitybridge.org/projects/laminas-project",
+                    "type": "community_bridge"
+                }
+            ],
+            "time": "2021-05-29T15:53:59+00:00"
         },
         {
             "name": "mikey179/vfsstream",
@@ -681,6 +762,55 @@
                 "source": "https://github.com/phpspec/prophecy/tree/1.13.0"
             },
             "time": "2021-03-17T13:42:18+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "0.5.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "fac86158ffc7392e49636f77e63684c026df43b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/fac86158ffc7392e49636f77e63684c026df43b8",
+                "reference": "fac86158ffc7392e49636f77e63684c026df43b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "require-dev": {
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^0.12.87",
+                "phpstan/phpstan-strict-rules": "^0.12.5",
+                "phpunit/phpunit": "^9.5",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "0.5-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/0.5.6"
+            },
+            "time": "2021-08-31T08:08:22+00:00"
         },
         {
             "name": "phpunit/php-code-coverage",
@@ -2068,64 +2198,98 @@
             "time": "2020-09-28T06:39:44+00:00"
         },
         {
-            "name": "squizlabs/php_codesniffer",
-            "version": "2.9.2",
+            "name": "slevomat/coding-standard",
+            "version": "7.0.15",
             "source": {
                 "type": "git",
-                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745"
+                "url": "https://github.com/slevomat/coding-standard.git",
+                "reference": "cc80e59f9b4ca642f02dc1b615c37a9afc2a0f80"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/2acf168de78487db620ab4bc524135a13cfe6745",
-                "reference": "2acf168de78487db620ab4bc524135a13cfe6745",
+                "url": "https://api.github.com/repos/slevomat/coding-standard/zipball/cc80e59f9b4ca642f02dc1b615c37a9afc2a0f80",
+                "reference": "cc80e59f9b4ca642f02dc1b615c37a9afc2a0f80",
+                "shasum": ""
+            },
+            "require": {
+                "dealerdirect/phpcodesniffer-composer-installer": "^0.6.2 || ^0.7",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpdoc-parser": "0.5.1 - 0.5.6",
+                "squizlabs/php_codesniffer": "^3.6.0"
+            },
+            "require-dev": {
+                "phing/phing": "2.17.0",
+                "php-parallel-lint/php-parallel-lint": "1.3.1",
+                "phpstan/phpstan": "0.12.98",
+                "phpstan/phpstan-deprecation-rules": "0.12.6",
+                "phpstan/phpstan-phpunit": "0.12.22",
+                "phpstan/phpstan-strict-rules": "0.12.11",
+                "phpunit/phpunit": "7.5.20|8.5.5|9.5.9"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "7.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "SlevomatCodingStandard\\": "SlevomatCodingStandard"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Slevomat Coding Standard for PHP_CodeSniffer complements Consistence Coding Standard by providing sniffs with additional checks.",
+            "support": {
+                "issues": "https://github.com/slevomat/coding-standard/issues",
+                "source": "https://github.com/slevomat/coding-standard/tree/7.0.15"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/kukulich",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/slevomat/coding-standard",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2021-09-09T10:29:09+00:00"
+        },
+        {
+            "name": "squizlabs/php_codesniffer",
+            "version": "3.6.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/squizlabs/PHP_CodeSniffer.git",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/squizlabs/PHP_CodeSniffer/zipball/ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
+                "reference": "ffced0d2c8fa8e6cdc4d695a743271fab6c38625",
                 "shasum": ""
             },
             "require": {
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": ">=5.1.2"
+                "php": ">=5.4.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~4.0"
+                "phpunit/phpunit": "^4.0 || ^5.0 || ^6.0 || ^7.0"
             },
             "bin": [
-                "scripts/phpcs",
-                "scripts/phpcbf"
+                "bin/phpcs",
+                "bin/phpcbf"
             ],
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "2.x-dev"
+                    "dev-master": "3.x-dev"
                 }
-            },
-            "autoload": {
-                "classmap": [
-                    "CodeSniffer.php",
-                    "CodeSniffer/CLI.php",
-                    "CodeSniffer/Exception.php",
-                    "CodeSniffer/File.php",
-                    "CodeSniffer/Fixer.php",
-                    "CodeSniffer/Report.php",
-                    "CodeSniffer/Reporting.php",
-                    "CodeSniffer/Sniff.php",
-                    "CodeSniffer/Tokens.php",
-                    "CodeSniffer/Reports/",
-                    "CodeSniffer/Tokenizers/",
-                    "CodeSniffer/DocGenerators/",
-                    "CodeSniffer/Standards/AbstractPatternSniff.php",
-                    "CodeSniffer/Standards/AbstractScopeSniff.php",
-                    "CodeSniffer/Standards/AbstractVariableSniff.php",
-                    "CodeSniffer/Standards/IncorrectPatternException.php",
-                    "CodeSniffer/Standards/Generic/Sniffs/",
-                    "CodeSniffer/Standards/MySource/Sniffs/",
-                    "CodeSniffer/Standards/PEAR/Sniffs/",
-                    "CodeSniffer/Standards/PSR1/Sniffs/",
-                    "CodeSniffer/Standards/PSR2/Sniffs/",
-                    "CodeSniffer/Standards/Squiz/Sniffs/",
-                    "CodeSniffer/Standards/Zend/Sniffs/"
-                ]
             },
             "notification-url": "https://packagist.org/downloads/",
             "license": [
@@ -2138,7 +2302,7 @@
                 }
             ],
             "description": "PHP_CodeSniffer tokenizes PHP, JavaScript and CSS files and detects violations of a defined set of coding standards.",
-            "homepage": "http://www.squizlabs.com/php-codesniffer",
+            "homepage": "https://github.com/squizlabs/PHP_CodeSniffer",
             "keywords": [
                 "phpcs",
                 "standards"
@@ -2148,7 +2312,7 @@
                 "source": "https://github.com/squizlabs/PHP_CodeSniffer",
                 "wiki": "https://github.com/squizlabs/PHP_CodeSniffer/wiki"
             },
-            "time": "2018-11-07T22:31:41+00:00"
+            "time": "2021-04-09T00:54:41+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -2278,6 +2442,61 @@
                 }
             ],
             "time": "2020-07-12T23:59:07+00:00"
+        },
+        {
+            "name": "webimpress/coding-standard",
+            "version": "1.2.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webimpress/coding-standard.git",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webimpress/coding-standard/zipball/8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "reference": "8f4a220de33f471a8101836f7ec72b852c3f9f03",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.3 || ^8.0",
+                "squizlabs/php_codesniffer": "^3.6"
+            },
+            "require-dev": {
+                "phpunit/phpunit": "^9.5.4"
+            },
+            "type": "phpcodesniffer-standard",
+            "extra": {
+                "dev-master": "1.2.x-dev",
+                "dev-develop": "1.3.x-dev"
+            },
+            "autoload": {
+                "psr-4": {
+                    "WebimpressCodingStandard\\": "src/WebimpressCodingStandard/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "BSD-2-Clause"
+            ],
+            "description": "Webimpress Coding Standard",
+            "keywords": [
+                "Coding Standard",
+                "PSR-2",
+                "phpcs",
+                "psr-12",
+                "webimpress"
+            ],
+            "support": {
+                "issues": "https://github.com/webimpress/coding-standard/issues",
+                "source": "https://github.com/webimpress/coding-standard/tree/1.2.2"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/michalbundyra",
+                    "type": "github"
+                }
+            ],
+            "time": "2021-04-12T12:51:27+00:00"
         },
         {
             "name": "webmozart/assert",

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -1,6 +1,15 @@
 <?xml version="1.0"?>
-<ruleset name="Laminas coding standard">
-    <rule ref="./vendor/laminas/laminas-coding-standard/ruleset.xml"/>
+<ruleset xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="vendor/squizlabs/php_codesniffer/phpcs.xsd">
+
+    <arg name="basepath" value="."/>
+    <arg name="cache" value=".phpcs-cache"/>
+    <arg name="colors"/>
+    <arg name="extensions" value="php"/>
+    <arg name="parallel" value="80"/>
+
+    <!-- Show progress -->
+    <arg value="p"/>
 
     <!-- Paths to check -->
     <file>src</file>
@@ -8,4 +17,7 @@
     <file>bin/laminas-development-mode</file>
     <file>development.config.php.dist</file>
     <file>development.local.php.dist</file>
+
+    <!-- Include all rules from the Laminas Coding Standard -->
+    <rule ref="LaminasCodingStandard"/>
 </ruleset>

--- a/src/AutoComposer.php
+++ b/src/AutoComposer.php
@@ -1,7 +1,16 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Laminas\DevelopmentMode;
+
+use function getenv;
+use function is_resource;
+use function printf;
+use function var_export;
+
+use const PHP_EOL;
+use const STDERR;
 
 /**
  * Automatically switch to and from development mode based on type of composer
@@ -17,26 +26,21 @@ namespace Laminas\DevelopmentMode;
  */
 class AutoComposer
 {
-    const COMPOSER_DEV_MODE = 'COMPOSER_DEV_MODE';
+    public const COMPOSER_DEV_MODE = 'COMPOSER_DEV_MODE';
 
-    /**
-     * @var value of COMPOSER_DEV_MODE
-     */
+    /** @var string Value of COMPOSER_DEV_MODE */
     private $composerDevMode;
 
-    /**
-     * @var resource
-     */
+    /** @var resource */
     private $errorStream;
 
+    /** @var string[] */
     private $expectedValues = [
         '0', // production mode
         '1', // development mode
     ];
 
-    /**
-     * @param string Path to project.
-     */
+    /** @var string Path to project. */
     private $projectDir;
 
     /**
@@ -46,8 +50,8 @@ class AutoComposer
     public function __construct($projectDir = '', $errorStream = null)
     {
         $this->composerDevMode = getenv(self::COMPOSER_DEV_MODE);
-        $this->projectDir = $projectDir;
-        $this->errorStream = is_resource($errorStream) ? $errorStream : STDERR;
+        $this->projectDir      = $projectDir;
+        $this->errorStream     = is_resource($errorStream) ? $errorStream : STDERR;
     }
 
     /**

--- a/src/Command.php
+++ b/src/Command.php
@@ -1,7 +1,15 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Laminas\DevelopmentMode;
+
+use function array_shift;
+use function count;
+use function fwrite;
+
+use const PHP_EOL;
+use const STDERR;
 
 class Command
 {

--- a/src/ConfigDiscoveryTrait.php
+++ b/src/ConfigDiscoveryTrait.php
@@ -1,33 +1,33 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Laminas\DevelopmentMode;
 
 use RuntimeException;
+
+use function file_exists;
+use function is_array;
+use function sprintf;
+use function unlink;
+
+use const PHP_EOL;
 
 /**
  * Shared functionality for the Disable/Enable commands.
  */
 trait ConfigDiscoveryTrait
 {
-    /**
-     * @var null|array
-     */
+    /** @var null|array */
     private $applicationConfig;
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $applicationConfigPath = 'config/application.config.php';
 
-    /**
-     * @var string
-     */
+    /** @var string */
     private $mezzioConfigPath = 'config/config.php';
 
-    /**
-     * @var string Base name for configuration cache.
-     */
+    /** @var string Base name for configuration cache. */
     private $configCacheBase = 'module-config-cache';
 
     /**
@@ -109,8 +109,8 @@ trait ConfigDiscoveryTrait
      * Raises an exception if retrieved configuration is not an array.
      *
      * @return array
-     * @throws RuntimeException if config/application.config.php does not
-     *     return an array
+     * @throws RuntimeException If config/application.config.php does not
+     *     return an array.
      */
     private function getApplicationConfig()
     {

--- a/src/Disable.php
+++ b/src/Disable.php
@@ -1,25 +1,31 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Laminas\DevelopmentMode;
 
 use RuntimeException;
 
+use function file_exists;
+use function fwrite;
+use function is_resource;
+use function sprintf;
+use function unlink;
+
+use const PHP_EOL;
+use const STDERR;
+
 class Disable
 {
     use ConfigDiscoveryTrait;
 
-    const DEVEL_CONFIG = 'config/development.config.php';
-    const DEVEL_LOCAL  = 'config/autoload/development.local.php';
+    public const DEVEL_CONFIG = 'config/development.config.php';
+    public const DEVEL_LOCAL  = 'config/autoload/development.local.php';
 
-    /**
-     * @var resource
-     */
+    /** @var resource */
     private $errorStream;
 
-    /**
-     * @param string Path to project.
-     */
+    /** @var string Path to project. */
     private $projectDir;
 
     /**
@@ -28,7 +34,7 @@ class Disable
      */
     public function __construct($projectDir = '', $errorStream = null)
     {
-        $this->projectDir = $projectDir;
+        $this->projectDir  = $projectDir;
         $this->errorStream = is_resource($errorStream) ? $errorStream : STDERR;
     }
 

--- a/src/Enable.php
+++ b/src/Enable.php
@@ -1,27 +1,37 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Laminas\DevelopmentMode;
 
 use RuntimeException;
 
+use function basename;
+use function copy;
+use function file_exists;
+use function fwrite;
+use function in_array;
+use function is_resource;
+use function sprintf;
+use function symlink;
+
+use const PHP_EOL;
+use const PHP_OS;
+use const STDERR;
+
 class Enable
 {
     use ConfigDiscoveryTrait;
 
-    const DEVEL_CONFIG      = 'config/development.config.php';
-    const DEVEL_CONFIG_DIST = 'config/development.config.php.dist';
-    const DEVEL_LOCAL       = 'config/autoload/development.local.php';
-    const DEVEL_LOCAL_DIST  = 'config/autoload/development.local.php.dist';
+    public const DEVEL_CONFIG      = 'config/development.config.php';
+    public const DEVEL_CONFIG_DIST = 'config/development.config.php.dist';
+    public const DEVEL_LOCAL       = 'config/autoload/development.local.php';
+    public const DEVEL_LOCAL_DIST  = 'config/autoload/development.local.php.dist';
 
-    /**
-     * @var resource
-     */
+    /** @var resource */
     private $errorStream;
 
-    /**
-     * @param string Path to project.
-     */
+    /** @var string Path to project. */
     private $projectDir;
 
     /**
@@ -30,7 +40,7 @@ class Enable
      */
     public function __construct($projectDir = '', $errorStream = null)
     {
-        $this->projectDir = $projectDir;
+        $this->projectDir  = $projectDir;
         $this->errorStream = is_resource($errorStream) ? $errorStream : STDERR;
     }
 

--- a/src/Help.php
+++ b/src/Help.php
@@ -1,14 +1,16 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Laminas\DevelopmentMode;
 
+use function fwrite;
+use function is_resource;
+
 class Help
 {
-    /**
-     * @var string
-     */
-    private $message = <<< EOH
+    /** @var string */
+    private $message = <<<EOH
 Enable/Disable development mode.
 
 Usage:

--- a/src/Status.php
+++ b/src/Status.php
@@ -1,15 +1,19 @@
 <?php
 
+declare(strict_types=1);
 
 namespace Laminas\DevelopmentMode;
 
+use function file_exists;
+use function sprintf;
+
+use const PHP_EOL;
+
 class Status
 {
-    const DEVEL_CONFIG = 'config/development.config.php';
+    public const DEVEL_CONFIG = 'config/development.config.php';
 
-    /**
-     * @param string
-     */
+    /** @var string */
     private $develConfigFile;
 
     /**

--- a/test/AutoComposerTest.php
+++ b/test/AutoComposerTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace LaminasTest\DevelopmentMode;
 
@@ -7,6 +8,13 @@ use Laminas\DevelopmentMode\AutoComposer;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamContainer;
 use PHPUnit\Framework\TestCase;
+
+use function fclose;
+use function fopen;
+use function is_resource;
+use function putenv;
+
+use const PHP_EOL;
 
 class AutoComposerTest extends TestCase
 {
@@ -20,12 +28,12 @@ class AutoComposerTest extends TestCase
 
     public function setUp(): void
     {
-        $this->projectDir = vfsStream::setup('project', null, [
+        $this->projectDir  = vfsStream::setup('project', null, [
             'config' => [
                 'autoload' => [],
             ],
-            'cache' => [],
-            'data' => [],
+            'cache'  => [],
+            'data'   => [],
         ]);
         $this->errorStream = fopen('php://memory', 'w+');
     }

--- a/test/DisableTest.php
+++ b/test/DisableTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace LaminasTest\DevelopmentMode;
 
@@ -7,6 +8,16 @@ use Laminas\DevelopmentMode\Disable;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamContainer;
 use PHPUnit\Framework\TestCase;
+
+use function fclose;
+use function file_exists;
+use function file_put_contents;
+use function fopen;
+use function fread;
+use function fseek;
+use function is_resource;
+
+use const PHP_EOL;
 
 class DisableTest extends TestCase
 {
@@ -26,15 +37,15 @@ class DisableTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->projectDir = vfsStream::setup('project', null, [
+        $this->projectDir  = vfsStream::setup('project', null, [
             'config' => [
                 'autoload' => [],
             ],
-            'cache' => [],
+            'cache'  => [],
         ]);
         $this->errorStream = fopen('php://memory', 'w+');
-        $this->configStub = '<' . "?php\nreturn [];";
-        $this->command = new Disable(vfsStream::url('project'), $this->errorStream);
+        $this->configStub  = '<' . "?php\nreturn [];";
+        $this->command     = new Disable(vfsStream::url('project'), $this->errorStream);
     }
 
     protected function tearDown(): void
@@ -44,6 +55,9 @@ class DisableTest extends TestCase
         }
     }
 
+    /**
+     * @return bool|string
+     */
     public function readErrorStream()
     {
         fseek($this->errorStream, 0);

--- a/test/EnableTest.php
+++ b/test/EnableTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace LaminasTest\DevelopmentMode;
 
@@ -7,6 +8,15 @@ use Laminas\DevelopmentMode\Enable;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamContainer;
 use PHPUnit\Framework\TestCase;
+
+use function fclose;
+use function file_exists;
+use function fopen;
+use function fread;
+use function fseek;
+use function is_resource;
+
+use const PHP_EOL;
 
 class EnableTest extends TestCase
 {
@@ -23,15 +33,15 @@ class EnableTest extends TestCase
 
     protected function setUp(): void
     {
-        $this->projectDir = vfsStream::setup('project', null, [
+        $this->projectDir  = vfsStream::setup('project', null, [
             'config' => [
                 'autoload' => [],
             ],
-            'cache' => [],
-            'data' => [],
+            'cache'  => [],
+            'data'   => [],
         ]);
         $this->errorStream = fopen('php://memory', 'w+');
-        $this->command = $this->getMockBuilder(Enable::class)
+        $this->command     = $this->getMockBuilder(Enable::class)
             ->setConstructorArgs([vfsStream::url('project'), $this->errorStream])
             ->setMethods(['supportsSymlinks'])
             ->getMock();
@@ -45,6 +55,9 @@ class EnableTest extends TestCase
         }
     }
 
+    /**
+     * @return bool|string
+     */
     public function readErrorStream()
     {
         fseek($this->errorStream, 0);

--- a/test/HelpTest.php
+++ b/test/HelpTest.php
@@ -1,10 +1,17 @@
 <?php
 
+declare(strict_types=1);
 
 namespace LaminasTest\DevelopmentMode;
 
 use Laminas\DevelopmentMode\Help;
 use PHPUnit\Framework\TestCase;
+
+use function fopen;
+use function fread;
+use function fseek;
+use function ob_get_clean;
+use function ob_start;
 
 class HelpTest extends TestCase
 {
@@ -20,7 +27,7 @@ class HelpTest extends TestCase
     public function testCanProvideAlternateStream()
     {
         $stream = fopen('php://memory', 'w+');
-        $help = new Help();
+        $help   = new Help();
         $help($stream);
         fseek($stream, 0);
         $this->assertStringContainsString('Enable/Disable development mode.', fread($stream, 4096));

--- a/test/RemoveCacheFileTrait.php
+++ b/test/RemoveCacheFileTrait.php
@@ -1,16 +1,19 @@
 <?php
 
+declare(strict_types=1);
 
 namespace LaminasTest\DevelopmentMode;
 
 use org\bovigo\vfs\vfsStream;
 
+use function file_put_contents;
+
 trait RemoveCacheFileTrait
 {
     public function setUpDefaultCacheFile()
     {
-        $base = vfsStream::url('project');
-        $config = <<< EOC
+        $base   = vfsStream::url('project');
+        $config = <<<EOC
 <?php
 return [
     'module_listener_options' => [
@@ -25,8 +28,8 @@ EOC;
 
     public function setUpCustomCacheFile()
     {
-        $base = vfsStream::url('project');
-        $config = <<< EOC
+        $base   = vfsStream::url('project');
+        $config = <<<EOC
 <?php
 return [
     'module_listener_options' => [
@@ -42,8 +45,8 @@ EOC;
 
     public function setUpDefaultMezzioCacheFile()
     {
-        $cache = vfsStream::url('project/data/config-cache.php');
-        $config = <<< EOC
+        $cache  = vfsStream::url('project/data/config-cache.php');
+        $config = <<<EOC
 <?php
 return [
     'config_cache_path' => '{$cache}',

--- a/test/StatusTest.php
+++ b/test/StatusTest.php
@@ -1,5 +1,6 @@
 <?php
 
+declare(strict_types=1);
 
 namespace LaminasTest\DevelopmentMode;
 
@@ -7,6 +8,9 @@ use Laminas\DevelopmentMode\Status;
 use org\bovigo\vfs\vfsStream;
 use org\bovigo\vfs\vfsStreamContainer;
 use PHPUnit\Framework\TestCase;
+
+use function ob_get_clean;
+use function ob_start;
 
 class StatusTest extends TestCase
 {


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| QA            | yes

### Description

This PR updates the `laminas-coding-standard` to version `2.3.0` and provides necessary code changes.