### PR TITLE
Fixes Issue #5

### DIFF
--- a/src/ConfigDiscoveryTrait.php
+++ b/src/ConfigDiscoveryTrait.php
@@ -116,7 +116,7 @@ trait ConfigDiscoveryTrait
             return $this->applicationConfig;
         }
 
-        $configFile = isset($this->projectDir)
+        $configFile = !empty($this->projectDir)
             ? sprintf('%s/%s', $this->projectDir, $this->applicationConfigPath)
             : $this->applicationConfigPath;
 


### PR DESCRIPTION
|    Q          |   A
|-------------- | ------
| Documentation |no
| Bugfix        | yes
| BC Break      | no
| New Feature   | no
| RFC           | no
| QA            | no

### Description

When searching for the config dir location, isset always returned true for projectDir since it was an empty string by the constructor defaults. 
Resulting in a `file_exists()` on `/config/application.config` instead of `config/application.config`
